### PR TITLE
update in 2024/5/14

### DIFF
--- a/MNSIM/Accuracy_Model/Crossbar_accuracy.py
+++ b/MNSIM/Accuracy_Model/Crossbar_accuracy.py
@@ -12,6 +12,8 @@ test_SimConfig_path = os.path.join(os.path.dirname(os.path.dirname(os.getcwd()))
 
 class crossbar_accuracy():
     def __init__(self, SimConfig_path):
+        #linqiiushi:add SimConfig_path(line below)
+        #SimConfig_path = os.path.abspath(os.path.join(os.getcwd(),'..','SimConfig',SimConfig_path))
         self.SimConfig_path = SimConfig_path
         xbar = crossbar(SimConfig_path)
         print("Hardware config file is loaded:", SimConfig_path)

--- a/MNSIM/Accuracy_Model/Weight_update.py
+++ b/MNSIM/Accuracy_Model/Weight_update.py
@@ -14,7 +14,8 @@ def weight_update(SimConfig_path, weight, is_SAF=0, is_Variation=0, is_Rratio=0)
     # print("Hardware config file is loaded:", SimConfig_path)
     wu_config = cp.ConfigParser()
     wu_config.read(SimConfig_path, encoding='UTF-8')
-    SAF_dist = list(map(int, wu_config.get('Device level', 'Device_SAF').split(',')))
+    
+    SAF_dist = list(map(float, wu_config.get('Device level', 'Device_SAF').split(',')))
     variation = float(wu_config.get('Device level', 'Device_Variation'))
     device_level = int(wu_config.get('Device level', 'Device_Level'))
     assert device_level >= 0, "NVM resistance level < 0"

--- a/MNSIM/Area_Model/Model_Area.py
+++ b/MNSIM/Area_Model/Model_Area.py
@@ -12,6 +12,9 @@ import pandas as pd
 from MNSIM.Hardware_Model.Tile import tile
 from MNSIM.Hardware_Model.Buffer import buffer
 from MNSIM.Hardware_Model.Adder import adder
+#linqiushi modified
+from MNSIM.Hardware_Model.Multiplier import multiplier
+#linqiushi above
 class Model_area():
     def __init__(self, NetStruct, SimConfig_path, multiple=None, TCG_mapping=None):
         self.NetStruct = NetStruct
@@ -70,6 +73,9 @@ class Model_area():
         self.global_buf = buffer(SimConfig_path=self.SimConfig_path,buf_level=1,default_buf_size=self.graph.global_buf_size)
         self.global_buf.calculate_buf_area()
         self.global_add = adder(SimConfig_path=self.SimConfig_path,bitwidth=self.graph.global_adder_bitwidth)
+        #linqiushi modified 
+        self.global_mul=multiplier(SimConfig_path=self.SimConfig_path,bitwidth=self.graph.global_multiplier_bitwidth)
+        #linqiushi above
         self.global_add.calculate_adder_area()
         for i in range(self.total_layer_num):
             tile_num = self.graph.layer_tileinfo[i]['tilenum']
@@ -123,11 +129,29 @@ class Model_area():
             for i in range(self.total_layer_num):
                 print("Layer", i, ":")
                 layer_dict = self.NetStruct[i][0][0]
+                #linqiushi modified
                 if layer_dict['type'] == 'element_sum':
                     print("     Hardware area (global accumulator):", self.global_add.adder_area*self.graph.global_adder_num+self.global_buf.buf_area, "um^2")
+                elif layer_dict['type']=='element_multiply':
+                    print("     Hardware area (global accumulator):", self.global_mul.multiplier_area*self.graph.global_multiplier_num+self.global_buf.buf_area, "um^2")
                 else:
                     print("     Hardware area:", self.arch_area[i], "um^2")
-
+                #linqiushi above
+    #linqiushi modified
+    def area_output_CNNParted(self):
+        area_list=[]
+        
+        for i in range(self.total_layer_num):
+            layer_dict = self.NetStruct[i][0][0]
+            
+            if layer_dict['type'] == 'element_sum':
+                area_list.append(self.global_add.adder_area*self.graph.global_adder_num+self.global_buf.buf_area)
+            elif layer_dict['type']=='element_multiply':
+                area_list.append(self.global_mul.multiplier_area*self.graph.global_multiplier_num+self.global_buf.buf_area)
+            else:
+                area_list.append(self.arch_area[i])
+        return area_list
+    #linqiushi above
 if __name__ == '__main__':
     test_SimConfig_path = os.path.join(os.path.dirname(os.path.dirname(os.getcwd())), "SimConfig.ini")
     test_weights_file_path = os.path.join(os.path.dirname(os.path.dirname(os.getcwd())),

--- a/MNSIM/Hardware_Model/Multiplier.py
+++ b/MNSIM/Hardware_Model/Multiplier.py
@@ -1,0 +1,97 @@
+#linqiushi modified
+#!/usr/bin/python
+#-*-coding:utf-8-*-
+import configparser as cp
+import os
+import math
+test_SimConfig_path = os.path.join(os.path.dirname(os.path.dirname(os.getcwd())),"SimConfig.ini")
+	#Default SimConfig file path: MNSIM_Python/SimConfig.ini
+
+
+class multiplier(object):
+	def __init__(self, SimConfig_path, bitwidth = None):
+		# frequency unit: MHz
+		multiplier_config = cp.ConfigParser()
+		multiplier_config.read(SimConfig_path, encoding='UTF-8')
+		self.multiplier_tech = int(multiplier_config.get('Digital module', 'Multiplier_Tech'))
+		self.multiplier_area = float(multiplier_config.get('Digital module', 'Multiplier_Area'))
+		self.multiplier_power = float(multiplier_config.get('Digital module', 'Multiplier_Power'))
+		if bitwidth is None:
+			self.multiplier_bitwidth = 8
+		else:
+			self.multiplier_bitwidth = bitwidth
+		assert self.multiplier_bitwidth > 0
+		self.multiplier_frequency = float(multiplier_config.get('Digital module', 'Digital_Frequency'))
+		if self.multiplier_frequency is None:
+			self.multiplier_frequency = 100
+		assert self.multiplier_frequency > 0
+		self.multiplier_latency = 1.0/self.multiplier_frequency
+		self.multiplier_energy = 0
+		self.calculate_multiplier_power()
+
+	def calculate_multiplier_area(self):
+		# unit: um^2
+		if self.multiplier_area == 0:
+			multiplier_area_dict = {130: 10*14*130*130/1e6, #ref: Implementation of an Efficient 14-Transistor Full multiplier (.18μm technology) Using DTMOS 2.5e-9
+							   65: 1.42,#10*14*65*65/1e6,
+							   55: 10*14*55*55/1e6,
+							   45: 10*14*45*45/1e6,
+							   28: 10*14*28*28/1e6
+			}
+			# TODO: add circuits simulation results
+			if self.multiplier_tech <= 28:
+				self.multiplier_area = multiplier_area_dict[28] * self.multiplier_bitwidth
+			elif self.multiplier_tech <= 45:
+				self.multiplier_area = multiplier_area_dict[45] * self.multiplier_bitwidth
+			elif self.multiplier_tech <= 55:
+				self.multiplier_area = multiplier_area_dict[55] * self.multiplier_bitwidth
+			elif self.multiplier_tech <= 65:
+				self.multiplier_area = multiplier_area_dict[65] * self.multiplier_bitwidth
+			else:
+				self.multiplier_area = multiplier_area_dict[130] * self.multiplier_bitwidth
+
+	def calculate_multiplier_power(self):
+		# unit: W
+		if self.multiplier_power == 0:
+			multiplier_power_dict = {130: 2.5e-9,
+							   65: 3e-7,
+							   55: 2.5e-9,
+							   45: 2.5e-9,
+							   28: 2.5e-9
+			}
+			# TODO: add circuits simulation results
+			if self.multiplier_tech <= 28:
+				self.multiplier_power = multiplier_power_dict[28] * self.multiplier_bitwidth
+			elif self.multiplier_tech <= 45:
+				self.multiplier_power = multiplier_power_dict[45] * self.multiplier_bitwidth
+			elif self.multiplier_tech <= 55:
+				self.multiplier_power = multiplier_power_dict[55] * self.multiplier_bitwidth
+			elif self.multiplier_tech <= 65:
+				self.multiplier_power = multiplier_power_dict[65] * self.multiplier_bitwidth
+			else:
+				self.multiplier_power = multiplier_power_dict[130] * self.multiplier_bitwidth
+
+	def calculate_multiplier_energy(self):
+		assert self.multiplier_power >= 0
+		assert self.multiplier_latency >= 0
+		self.multiplier_energy = self.multiplier_latency * self.multiplier_power
+
+	def multiplier_output(self):
+		print("multiplier_area:", self.multiplier_area, "um^2")
+		print("multiplier_bitwidth:", self.multiplier_bitwidth, "bit")
+		print("multiplier_power:", self.multiplier_power, "W")
+		print("multiplier_latency:", self.multiplier_latency, "ns")
+		print("multiplier_energy:", self.multiplier_energy, "nJ")
+	
+def multiplier_test():
+	print("load file:",test_SimConfig_path)
+	_multiplier = multiplier(test_SimConfig_path)
+	_multiplier.calculate_multiplier_area()
+	_multiplier.calculate_multiplier_power()
+	_multiplier.calculate_multiplier_energy()
+	_multiplier.multiplier_output()
+
+
+if __name__ == '__main__':
+	multiplier_test()
+#linqiushi above

--- a/MNSIM/Hardware_Model/Tile.py
+++ b/MNSIM/Hardware_Model/Tile.py
@@ -243,6 +243,7 @@ class tile(ProcessElement):
 		if layer_type == 'pooling':
 			self.tile_pooling.calculate_Pooling_power()
 			self.tile_pooling_read_power = self.tile_pooling.Pooling_power
+		
 		elif layer_type == 'conv' or layer_type  == 'fc':
 			self.calculate_PE_read_power_fast(max_column=max_column, max_row=max_row, max_group=max_group,
 											  SimConfig_path=SimConfig_path, default_inbuf_size = default_inbuf_size)

--- a/MNSIM/Interface/Imagenet.py
+++ b/MNSIM/Interface/Imagenet.py
@@ -1,0 +1,69 @@
+#-*-coding:utf-8-*-
+# import multiprocessing
+# multiprocessing.set_start_method('spawn', True)
+import os
+
+import torch.utils.data as Data
+import torchvision
+import torchvision.transforms as Transforms
+
+TRAIN_BATCH_SIZE = 128
+TRAIN_NUM_WORKERS = 0
+TEST_BATCH_SIZE = 100
+TEST_NUM_WORKERS = 0
+
+#ImageNet_PATH needs to be changed
+def get_dataloader(ImageNet_PATH='/share/linqiushi-nfs', batch_size=64, workers=3, pin_memory=True): 
+    
+    traindir = os.path.join(ImageNet_PATH, 'Imagenet-train/ILSVRC2012_img_train')
+    valdir   = os.path.join(ImageNet_PATH, 'Imagenet-value')
+    print('traindir = ',traindir)
+    print('valdir = ',valdir)
+    
+    normalizer = Transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                     std=[0.229, 0.224, 0.225])
+
+    train_dataset = torchvision.datasets.ImageFolder(
+        traindir,
+        Transforms.Compose([
+            Transforms.RandomResizedCrop(224),
+            Transforms.RandomHorizontalFlip(),
+            Transforms.ToTensor(),
+            normalizer
+        ])
+    )
+    
+    val_dataset = torchvision.datasets.ImageFolder(
+        valdir,
+        Transforms.Compose([
+            Transforms.Resize(256),
+            Transforms.CenterCrop(224),
+            Transforms.ToTensor(),
+            normalizer
+        ])
+    )
+    print('train_dataset = ',len(train_dataset))
+    print('val_dataset   = ',len(val_dataset))
+    
+    train_loader = Data.DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=workers,
+        pin_memory=pin_memory,
+        sampler=None
+    )
+    val_loader = Data.DataLoader(
+        val_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=workers,
+        pin_memory=pin_memory
+    )
+    return train_loader, val_loader
+
+if __name__  == '__main__':
+    train_loader, test_loader = get_dataloader()
+    print(len(train_loader))
+    print(len(test_loader))
+    print('this is the Imagenet100 dataset, output shape is 224x224x3')

--- a/MNSIM/Interface/alg_test_training_entrance.py
+++ b/MNSIM/Interface/alg_test_training_entrance.py
@@ -30,6 +30,7 @@ else:
     assert 0
 
 print(f'args is {args}')
+
 # dataloader
 dataset_module = import_module(f'MNSIM.Interface.{args.dataset}')
 train_loader, test_loader = dataset_module.get_dataloader()
@@ -39,13 +40,18 @@ if args.dataset.endswith('cifar10'):
     num_classes = 10
 elif args.dataset.endswith('cifar100'):
     num_classes = 100
+elif args.dataset.endswith('Imagenet'):
+    num_classes=1000
 else:
     assert 0, f'unknown dataset'
 
 net = net_module.get_net(cate = args.net, num_classes = num_classes)
+
 # train
 train_module = import_module(f'MNSIM.Interface.{args.train}')
 device = torch.device(f'cuda:{args.gpu}' if torch.cuda.is_available() else 'cpu')
+print(torch.cuda.get_device_properties(1).total_memory)
+print(torch.cuda.memory_allocated(1))
 print(f'run on device {device}')
 # weights
 if args.weight is not None:
@@ -54,6 +60,8 @@ if args.weight is not None:
     # net.load_state_dict(torch.load(args.weight))
 if args.mode == 'train':
     train_module.train_net(net, train_loader, test_loader, device, args.prefix)
+    
+    
 if args.mode == 'test':
     assert args.weight
     # net.load_change_weights(torch.load(args.weight))

--- a/MNSIM/Interface/cifar10.py
+++ b/MNSIM/Interface/cifar10.py
@@ -7,9 +7,9 @@ import torch.utils.data as Data
 import torchvision
 import torchvision.transforms as Transforms
 
-TRAIN_BATCH_SIZE = 128
+TRAIN_BATCH_SIZE = 256
 TRAIN_NUM_WORKERS = 0
-TEST_BATCH_SIZE = 100
+TEST_BATCH_SIZE = 256
 TEST_NUM_WORKERS = 0
 
 def get_dataloader():
@@ -20,6 +20,7 @@ def get_dataloader():
         transform = Transforms.Compose([
             Transforms.Pad(padding = 4),
             Transforms.RandomCrop(32),
+            #Transforms.Resize((224,224)),
             Transforms.RandomHorizontalFlip(),
             Transforms.ToTensor(),
         ])

--- a/MNSIM/Interface/network.py
+++ b/MNSIM/Interface/network.py
@@ -25,6 +25,7 @@ class NetworkGraph(nn.Module):
             assert 'type' in layer_config.keys()
             if layer_config['type'] in quantize.QuantizeLayerStr:
                 # configure quantization setting of 'conv' and 'fc'
+                
                 layer = quantize.QuantizeLayer(hardware_config, layer_config, quantize_config)
             elif layer_config['type'] in quantize.StraightLayerStr:
                 layer = quantize.StraightLayer(hardware_config, layer_config, quantize_config)
@@ -42,6 +43,7 @@ class NetworkGraph(nn.Module):
         tensor_list = [x]
         for i, layer in enumerate(self.layer_list):
             # find the input tensor
+           
             input_index = self.input_index_list[i]
             assert len(input_index) in [1, 2, 4] #"4" for GoogLeNet
             if len(input_index) == 1:
@@ -68,7 +70,50 @@ class NetworkGraph(nn.Module):
                     adc_action,
                     )
                 )
+        
         return tensor_list[-1]
+   
+    # CNNParted_set_weights_forward:  the interface with CNNParted,accuracy evaluation
+    def CNNParted_set_weights_forward(self,x,tensor_list_CNNParted,start_num,end_num,adc_action='SCALE'):
+        net_bit_weights=self.get_weights()
+        quantize.last_activation_scale = self.input_params['activation_scale']
+        quantize.last_activation_bit = self.input_params['activation_bit']
+        # filter None
+        net_bit_weights = list(filter(lambda x:x!=None, net_bit_weights))
+        count=0
+        for i,layer in enumerate(self.layer_list[start_num:end_num],start=start_num):
+            # find the input tensor
+            input_index = self.input_index_list[i]
+            assert len(input_index) in [1, 2]
+            if isinstance(layer, quantize.QuantizeLayer):
+                tensor_list_CNNParted.append(layer.set_weights_forward(tensor_list_CNNParted[input_index[0] + i + 1], net_bit_weights[count], adc_action))
+               
+                count = count + 1
+            else:
+                if len(input_index) == 1:
+                    tensor_list_CNNParted.append(layer.forward(tensor_list_CNNParted[input_index[0] + i + 1], 'FIX_TRAIN', None))
+                else:
+                    tensor_list_CNNParted.append(
+                    layer.forward([
+                        tensor_list_CNNParted[input_index[0] + i + 1],
+                        tensor_list_CNNParted[input_index[1] + i + 1],
+                    ],
+                    'FIX_TRAIN',
+                    None,
+                    )
+                )
+        return tensor_list_CNNParted,tensor_list_CNNParted[-1]
+    # CNNParted Interface : calculate_equal_bit: the equaled pim supported quantization bit, using in CNNParted step2
+    def calculate_equal_bit(self):
+        #calculated in quantize.py   (layers)
+        equal_bit_list=[]
+        for index,layer in enumerate(self.layer_list):
+            if layer.layer_config['type']=='conv' or layer.layer_config['type']=='fc':
+                equal_bit_list.append(layer.calculate_equal_bit())
+            
+        return equal_bit_list
+        
+   
     def get_weights(self):
         net_bit_weights = []
         for layer in self.layer_list:
@@ -117,9 +162,13 @@ class NetworkGraph(nn.Module):
             assert len(input_index) in [1, 2]
                 # default: support resnet, thus the input_index has two values at most, for other networks with more branches, modify this value
             # print(tensor_list[input_index[0]+i+1].shape)
+           
             if len(input_index) == 1:
+          
                 tensor_list.append(layer.structure_forward(tensor_list[input_index[0] + i + 1]))
+                
             else:
+           
                 tensor_list.append(
                     layer.structure_forward([
                         tensor_list[input_index[0] + i + 1],
@@ -149,7 +198,7 @@ class NetworkGraph(nn.Module):
         # concat and split
         tmp_state_dict = collections.OrderedDict()
         for tmp_key, key_list in keys_map.items():
-            if len(key_list) == 1 and tmp_key == key_list[0]:
+            if len(key_list) == 1 and tmp_key==key_list[0]:
                 # print('origin weights')
                 # weights on PIM is the original weights
                 tmp_state_dict[tmp_key] = state_dict[key_list[0]]
@@ -160,6 +209,7 @@ class NetworkGraph(nn.Module):
                 hardware_config = None
                 # retrieve the hardware config and 
                 for i in range(len(self.layer_list)):
+                    #prefix 'module' comes from  the dataparallel
                     name = f'layer_list.{i}'
                     if name == tmp_key:
                         layer_config = self.layer_list[i].layer_config
@@ -174,26 +224,133 @@ class NetworkGraph(nn.Module):
                 elif layer_config['type'] == 'fc':
                     split_len = hardware_config['xbar_size']
                 else:
+                    print(layer_config['type'])
                     assert 0, f'not support {layer_config["type"]}, only conv and fc layers have weights'
                 weights_list = torch.split(total_weights, split_len, dim = 1)
                 # load weights
                 for i, weights in enumerate(weights_list):
                     tmp_state_dict[tmp_key + f'.sublayer_list.{i}.weight'] = weights
+                
         # load weights
+       
         self.load_state_dict(tmp_state_dict)
+    #TODO:fix the loading of weights in different type
+    # def load_change_weights_different(self, state_dict,standart_dict):
+    #     #standart_dict:trained from MNSIM
+    #     count=0
+    #     flag=1
+    #     flagg=1
+    #     final_dict=collections.OrderedDict()
+    #     tmp_standart_dict=collections.OrderedDict()
+    #     num_key=collections.OrderedDict()
+    #     tmp1_state_dict=collections.OrderedDict()
+    #     #first clear the bit and last_value in standard_dict
+    #     for key in standart_dict.keys():
+    #         if 'last_value' in key  or re.search(r'sublayer_list\.[1-9]\d*',key) is not None :
+    #             if re.search(r'sublayer_list\.[1-9]\d*',key) is not None :
+    #                 count=count+1
+    #                 num_key[key]=[count]
+    #             continue
+    #         else:
+    #             count=0
+    #             tmp_standart_dict[key]=standart_dict[key]
+    #     for key in state_dict.keys():
+    #         if 'Conv_/features/features' in key  or 'Gemm' in key :
+    #             tmp1_state_dict[key]=state_dict[key]
+    #         else:
+    #             continue
+    #     for (key1,key2) in zip(tmp1_state_dict.keys(),tmp_standart_dict.keys()):
+    #         if '_amax' in key1:
+    #             key_bit_scale_list=key2
+    #             scale=tmp1_state_dict[key1]
+    #             activation_scale=scale/2**9 #quantize_config_list[1]['activation_bit']
+    #             weight_scale=scale/2**9 #quantize_config_list[1]['weight_bit']
+    #             value_bit_scale_list=torch.empty(3,2)
+    #             value_bit_scale_list[0,0]=9 #quantize_config_list[1]['activation_bit']
+    #             value_bit_scale_list[0,1]=activation_scale
+    #             value_bit_scale_list[1,0]=9 #quantize_config_list[1]['weight_bit']
+    #             value_bit_scale_list[0,1]=weight_scale
+    #             value_bit_scale_list[2,0]=9 #quantize_config_list[1]['activation_bit']
+    #             value_bit_scale_list[0,1]=activation_scale
+    #             final_dict[key_bit_scale_list]=value_bit_scale_list
+    #         else:
+    #             final_dict[key2]=tmp1_state_dict[key1]
+          
+    #     for keys in final_dict.keys():
+    #         print("keys",keys)
+    #     for keys in final_dict.keys():
+    #         if keys in standart_dict.keys():
+    #             #keys:special
+    #             standart_dict[keys]=final_dict[keys]
+    #     keys_map = collections.OrderedDict()
+    #     for key in standart_dict.keys():
+    #         tmp_key = re.sub('\.[a-z]{0,3}layer_list\.\d+\.weight$', '', key)
+    #         if tmp_key not in keys_map.keys():
+    #             keys_map[tmp_key] = [key]
+    #         else:
+    #             keys_map[tmp_key].append(key)
+    #     # concat and split
+    #     for key in standart_dict.keys():
+    #         print(key,standart_dict[key].shape)
+    #     tmp_state_dict = collections.OrderedDict()
+    #     for tmp_key, key_list in keys_map.items():
+    #         tmp_key = re.sub('module.', '', tmp_key)
+    #         if len(key_list) == 1 and tmp_key == re.sub('module.','',key_list[0]):
+    #             # weights on PIM is the original weights
+    #             tmp_state_dict[tmp_key] = standart_dict[key_list[0]]
+    #         else:
+    #             # get layer info
+    #             layer_config = None
+    #             hardware_config = None
+    #             # retrieve the hardware config and 
+    #             for i in range(len(self.layer_list)):
+    #                 #prefix 'module' comes from  the dataparallel
+    #                 name = f'layer_list.{i}'
+    #                 if name == tmp_key:
+    #                     layer_config = self.layer_list[i].layer_config
+    #                     hardware_config = self.layer_list[i].hardware_config
+    #             assert layer_config, 'layer must have layer config'
+    #             assert hardware_config, 'layer must have hardware config'
+    #             # concat weights
+    #             total_weights = standart_dict[key_list[0]]
+    #             # split weights according to HW parameters (along with output channel dimension)
+    #             if layer_config['type'] == 'conv':
+    #                 split_len = (hardware_config['xbar_size'] // (layer_config['kernel_size'] ** 2))
+    #             elif layer_config['type'] == 'fc':
+    #                 split_len = hardware_config['xbar_size']
+    #                 flag=0
+    #             else:
+    #                 print(layer_config['type'])
+    #                 assert 0, f'not support {layer_config["type"]}, only conv and fc layers have weights'
+    #             weights_list = torch.split(total_weights, split_len, dim = 1)
+    #             # load weights
+    #             for i, weights in enumerate(weights_list):
+    #                 if flag==0:
+    #                     tmp_state_dict[tmp_key + f'.sublayer_list.{i}.weight'] = weights.view(weights.shape[0],weights.shape[1])
+    #                 else:
+    #                     tmp_state_dict[tmp_key + f'.sublayer_list.{i}.weight'] = weights
+
+    #         flag=1
+    #     # load weights
+    #     self.load_state_dict(tmp_state_dict,strict=True)
+
 
 def get_net(hardware_config = None, cate = 'lenet', num_classes = 10):
     # define the NN structure
     # initial config
+    
     if hardware_config == None:
-        hardware_config = {'xbar_size': 512, 'input_bit': 2, 'weight_bit': 1, 'ADC_quantize_bit': 10, 'DAC_num': 256}
+        hardware_config = {'xbar_size': 256, 'input_bit': 2, 'weight_bit': 1, 'ADC_quantize_bit': 10, 'DAC_num': 256}
     # layer_config_list, quantize_config_list, and input_index_list
     layer_config_list = []
     quantize_config_list = []
     input_index_list = []
     # layer by layer
     # add new NN models here (conv/fc is followed by one bn layer automatically):
-    assert cate in ['lenet', 'vgg16', 'vgg8', 'alexnet', 'resnet18']
+    #assert cate in ['lenet', 'vgg16', 'vgg8', 'alexnet', 'resnet18']
+   
+    assert cate in ['lenet', 'vgg16', 'vgg8', 'alexnet', 'resnet18','EfficientNet']
+
     if cate.startswith('lenet'):
         layer_config_list.append({'type': 'conv', 'in_channels': 3, 'out_channels': 6, 'kernel_size': 5})
         layer_config_list.append({'type': 'relu'})
@@ -349,10 +506,294 @@ def get_net(hardware_config = None, cate = 'lenet', num_classes = 10):
         layer_config_list.append({'type': 'dropout'})
         layer_config_list.append({'type': 'relu'})
         layer_config_list.append({'type': 'fc', 'in_features': 512, 'out_features': num_classes})
+    #TODO: train the EfficientNet
+    elif cate.startswith('EfficientNet'):
+        layer_config_list.append({'type': 'conv', 'in_channels':3 , 'out_channels':32 , 'kernel_size': 3, 'padding': 1,'stride':2})
+        layer_config_list.append({'type': 'Swish'})
+        #block1
+        layer_config_list.append({'type': 'conv', 'in_channels':32 , 'out_channels':32 , 'kernel_size': 3, 'padding': 1,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 16, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 32, 'out_features': 8})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 8, 'out_features': 32})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]})                         
+        layer_config_list.append({'type': 'conv', 'in_channels':32 , 'out_channels':16 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        
+        
+      
+        
+        #block2
+        layer_config_list.append({'type': 'conv', 'in_channels':16 , 'out_channels':96 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':96 , 'out_channels':96 , 'kernel_size': 3, 'padding': 1,'stride':2,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 10, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 96, 'out_features': 4})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 4, 'out_features': 96})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':96 , 'out_channels':24 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        
+       
+        
+        #block2
+        layer_config_list.append({'type': 'conv', 'in_channels':24 , 'out_channels':144 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':144 , 'out_channels':144 , 'kernel_size': 3, 'padding': 1,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 7, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 144, 'out_features': 6})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 6, 'out_features': 144})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':144 , 'out_channels':24 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        
+  
+        
+        #block3
+        layer_config_list.append({'type': 'conv', 'in_channels':24 , 'out_channels':144 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':144 , 'out_channels':144 , 'kernel_size': 5, 'padding': 2,'stride':2,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 5, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 144, 'out_features': 6})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 6, 'out_features': 144})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':144 , 'out_channels':40 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+       
+        
+   
+        
+        #block3
+        layer_config_list.append({'type': 'conv', 'in_channels':40 , 'out_channels':240 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':240 , 'out_channels':240 , 'kernel_size': 5, 'padding': 2,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 4, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 240, 'out_features': 10})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 10, 'out_features': 240})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':240 , 'out_channels':40 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+       
+      
+        #block4
+        layer_config_list.append({'type': 'conv', 'in_channels':40 , 'out_channels':240 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':240 , 'out_channels':240 , 'kernel_size': 3, 'padding': 1,'stride':2,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 4, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 240, 'out_features': 10})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 10, 'out_features': 240})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':240 , 'out_channels':80 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+    
+        
+        #block4
+        layer_config_list.append({'type': 'conv', 'in_channels':80 , 'out_channels':480 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':480 , 'out_channels':480 , 'kernel_size': 3, 'padding': 1,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 4, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 480, 'out_features': 20})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 20, 'out_features': 480})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':480 , 'out_channels':80 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+        
+        #block4
+        layer_config_list.append({'type': 'conv', 'in_channels':80 , 'out_channels':480 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':480 , 'out_channels':480 , 'kernel_size': 3, 'padding': 1,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 4, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 480, 'out_features': 20})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 20, 'out_features': 480})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':480 , 'out_channels':80 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+        
+        
+        #block5
+        layer_config_list.append({'type': 'conv', 'in_channels':80 , 'out_channels':480 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':480 , 'out_channels':480 , 'kernel_size': 5, 'padding': 2,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 6, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 480, 'out_features': 20})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 20, 'out_features': 480})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':480 , 'out_channels':112 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        
+     
+        #block5
+        layer_config_list.append({'type': 'conv', 'in_channels':112 , 'out_channels':672 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':672 , 'out_channels':672 , 'kernel_size': 5, 'padding': 2,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 8, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 672, 'out_features': 28})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 28, 'out_features': 672})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':672 , 'out_channels':112 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+  
+        #block5
+        layer_config_list.append({'type': 'conv', 'in_channels':112 , 'out_channels':672 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':672 , 'out_channels':672 , 'kernel_size': 5, 'padding': 2,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 10, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 672, 'out_features': 28})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 28, 'out_features': 672})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':672 , 'out_channels':112 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+  
+       
+        #block6
+        layer_config_list.append({'type': 'conv', 'in_channels':112 , 'out_channels':672 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':672 , 'out_channels':672 , 'kernel_size': 5, 'padding': 2,'stride':2,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 6, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 672, 'out_features': 28})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 28, 'out_features': 672})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':672 , 'out_channels':192 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+   
+        #block6
+        layer_config_list.append({'type': 'conv', 'in_channels':192 , 'out_channels':1152 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels':1152 , 'kernel_size': 5, 'padding': 2,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 4, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 1152, 'out_features': 48})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 48, 'out_features': 1152})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels':192 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+        
+        #block6
+        layer_config_list.append({'type': 'conv', 'in_channels':192 , 'out_channels':1152 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels':1152 , 'kernel_size': 5, 'padding': 2,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 3, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 1152, 'out_features': 48})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 48, 'out_features': 1152})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels':192 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+     
+        #block6
+        layer_config_list.append({'type': 'conv', 'in_channels':192 , 'out_channels':1152 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels':1152 , 'kernel_size': 5, 'padding': 2,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 3, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 1152, 'out_features': 48})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 48, 'out_features': 1152})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels':192 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'element_sum', 'input_index': [-1, -15]})
+      
+        
+        #block7
+        layer_config_list.append({'type': 'conv', 'in_channels':192 , 'out_channels':1152 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels':1152 , 'kernel_size': 3, 'padding': 1,'stride':1,'depthwise':'separable'})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 7, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'fc', 'in_features': 1152, 'out_features': 48})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'fc', 'in_features': 48, 'out_features': 1152})
+        layer_config_list.append({'type': 'Sigmoid'})
+        layer_config_list.append({'type': 'element_multiply', 'input_index': [-1, -7]}) 
+        layer_config_list.append({'type': 'conv', 'in_channels':1152 , 'out_channels': 320, 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+      
+        
+        #end
+        layer_config_list.append({'type': 'conv', 'in_channels':320 , 'out_channels':1280 , 'kernel_size': 1})
+        layer_config_list.append({'type': 'Swish'})
+        layer_config_list.append({'type': 'pooling', 'mode': 'ADA', 'kernel_size': 11, 'stride': 1})
+        layer_config_list.append({'type': 'view'})
+        layer_config_list.append({'type': 'dropout'})
+        layer_config_list.append({'type': 'fc', 'in_features': 1280, 'out_features': num_classes})
+    
     else:
         assert 0, f'not support {cate}'
+    
     for i in range(len(layer_config_list)):
-        quantize_config_list.append({'weight_bit': 9, 'activation_bit': 9, 'point_shift': -2})
+        quantize_config_list.append({'weight_bit': 9, 'activation_bit':9, 'point_shift': -2})
         if 'input_index' in layer_config_list[i]:
             input_index_list.append(layer_config_list[i]['input_index'])
         else:
@@ -360,7 +801,7 @@ def get_net(hardware_config = None, cate = 'lenet', num_classes = 10):
                 # by default: the inputs of the current layer come from the outputs of the previous layer
     input_params = {'activation_scale': 1. / 255., 'activation_bit': 9, 'input_shape': (1, 3, 32, 32)}
         # change the input_shape according to datasets
-    # add bn for every conv
+    #add bn for every conv
     L = len(layer_config_list)
     for i in range(L-1, -1, -1):
         if layer_config_list[i]['type'] == 'conv':
@@ -373,7 +814,9 @@ def get_net(hardware_config = None, cate = 'lenet', num_classes = 10):
                 for relative_input_index in range(len(input_index_list[j])):
                     if j + input_index_list[j][relative_input_index] < i + 1:
                         input_index_list[j][relative_input_index] -= 1
+   
     # generate net
+    
     net = NetworkGraph(hardware_config, layer_config_list, quantize_config_list, input_index_list, input_params)
     return net
 

--- a/MNSIM/Interface/quantize.py
+++ b/MNSIM/Interface/quantize.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Function
-
+#
 # last_activation_scale, last_weight_scale for activation and weight scale in last calculation
 # last_activation_bit, last_weight_bit for activation and weight bit last time
 last_activation_scale = None
@@ -28,18 +28,21 @@ class QuantizeFunction(Function):
             last_weight_bit = qbit
             scale = torch.max(torch.abs(input)).item()
         elif mode == 'activation':
+            
             last_activation_bit = qbit
-            if training:
-                ratio = 0.707
-                tmp = last_value.item()
-                if tmp <= 0:
-                    tmp = 3 * torch.std(input).item() + torch.abs(torch.mean(input)).item()
-                else:
-                    # tmp = ratio * tmp + (1 - ratio) * torch.max(torch.abs(input)).item()
-                    tmp = ratio * tmp + (1 - ratio) * \
-                        (3 * torch.std(input).item() + torch.abs(torch.mean(input)).item())
-                last_value.data[0] = tmp
+            
+            ratio = 0.707
+            tmp = last_value.item()
+            if tmp <= 0:
+                tmp = 3 * torch.std(input).item() + torch.abs(torch.mean(input)).item()
+            else:
+                # tmp = ratio * tmp + (1 - ratio) * torch.max(torch.abs(input)).item()
+                tmp = ratio * tmp + (1 - ratio) * \
+                (3 * torch.std(input).item() + torch.abs(torch.mean(input)).item())
+            last_value.data[0] = tmp
+            
             scale = last_value.data[0]
+            
         else:
             assert 0, f'not support {mode}'
         # transfer
@@ -81,6 +84,7 @@ class QuantizeLayer(nn.Module):
                 # number of channels stored in one xbar
             complete_bar_num = self.layer_config['in_channels'] // channel_N
             residual_col_num = self.layer_config['in_channels'] % channel_N
+            
             in_channels_list = []
                 # each element stores the channel number in one xbar
             if residual_col_num > 0:
@@ -101,12 +105,27 @@ class QuantizeLayer(nn.Module):
                 self.layer_config['stride'] = 1
             if 'padding' not in self.layer_config.keys():
                 self.layer_config['padding'] = 0
-            self.sublayer_list = nn.ModuleList([nn.Conv2d(
+            if 'depthwise'not in self.layer_config.keys():
+                self.layer_config['depthwise']='normal'
+            if self.layer_config['depthwise']=='separable':
+                in_channels_list=[self.layer_config['in_channels']]
+                self.sublayer_list = nn.ModuleList([nn.Conv2d(
+                i, i, self.layer_config['kernel_size'],
+                stride = self.layer_config['stride'], padding = self.layer_config['padding'], dilation = 1, groups = i, bias = False
+                )
+                for i in in_channels_list]) 
+            else:
+                self.sublayer_list = nn.ModuleList([nn.Conv2d(
                 i, self.layer_config['out_channels'], self.layer_config['kernel_size'],
                 stride = self.layer_config['stride'], padding = self.layer_config['padding'], dilation = 1, groups = 1, bias = False
                 )
-                for i in in_channels_list])
-            self.split_input = channel_N
+                for i in in_channels_list])   
+        
+            if self.layer_config['depthwise']=='separable':
+                self.split_input=self.layer_config['in_channels']
+            else:    
+                self.split_input = channel_N
+        
         elif self.layer_config['type'] == 'fc':
             assert 'in_features' in self.layer_config.keys()
             complete_bar_num = self.layer_config['in_features'] // self.hardware_config['xbar_size']
@@ -121,12 +140,14 @@ class QuantizeLayer(nn.Module):
 
             # generate Module List
             assert 'out_features' in self.layer_config.keys()
-            self.sublayer_list = nn.ModuleList([nn.Linear(i, self.layer_config['out_features'], False) for i in in_features_list])
+            self.sublayer_list = nn.ModuleList([nn.Linear(i, self.layer_config['out_features'], None) for i in in_features_list])
             self.split_input = self.hardware_config['xbar_size']
         else:
             assert 0, f'not support {self.layer_config["type"]}'
         # self.last_value = nn.Parameter(torch.ones(1))
+        
         self.register_buffer('last_value', (-1) * torch.ones(1))
+ 
         # self.last_value[0] = 1
         self.register_buffer('bit_scale_list', torch.FloatTensor([
             [quantize_config['activation_bit'], -1],
@@ -144,6 +165,7 @@ class QuantizeLayer(nn.Module):
         for i in range(len(self.sublayer_list)):
             if i == 0:
                 output = self.sublayer_list[i](input_list[i])
+
             else:
                 output.add_(self.sublayer_list[i](input_list[i]))
         output_shape = output.shape
@@ -158,12 +180,15 @@ class QuantizeLayer(nn.Module):
             self.layer_info['Kernelsize'] = self.layer_config['kernel_size']
             self.layer_info['Stride'] = self.layer_config['stride']
             self.layer_info['Padding'] = self.layer_config['padding']
+            self.layer_info['Depthwise']=self.layer_config['depthwise']
             self.layer_info['Outputchannel'] = int(output_shape[1])
             self.layer_info['Outputsize'] = list(output_shape[2:])
         elif self.layer_config['type'] == 'fc':
             self.layer_info['type'] = 'fc'
             self.layer_info['Infeature'] = int(input_shape[1])
             self.layer_info['Outfeature'] = int(output_shape[1])
+            self.layer_info['Outputchannel'] = int(output_shape[1])
+            self.layer_info['Outputsize'] = list([1,1])
         else:
             assert 0, f'not support {self.layer_config["type"]}'
         self.layer_info['Inputbit'] = int(self.bit_scale_list[0,0].item())
@@ -175,6 +200,7 @@ class QuantizeLayer(nn.Module):
         else:
             self.layer_info['weight_bit_split_part'] = math.ceil((self.quantize_config['weight_bit']) / (self.hardware_config['weight_bit']))
         if 'input_index' in self.layer_config:
+           
             self.layer_info['Inputindex'] = self.layer_config['input_index']
         else:
             self.layer_info['Inputindex'] = [-1]
@@ -182,6 +208,7 @@ class QuantizeLayer(nn.Module):
         return output
     def forward(self, input, method = 'SINGLE_FIX_TEST', adc_action = 'SCALE'):
         METHOD = method
+       
         # float method
         if METHOD == 'TRADITION':
             input_list = torch.split(input, self.split_input, dim = 1)
@@ -194,8 +221,11 @@ class QuantizeLayer(nn.Module):
             return output
         # fix training
         if METHOD == 'FIX_TRAIN':
-            weight = torch.cat([l.weight for l in self.sublayer_list], dim = 1)
+           
+            weight=torch.cat([l.weight for l in self.sublayer_list], dim = 1)
+            
             # quantize weight
+            #weight = torch.cat([l.weight for l in self.sublayer_list], dim = 1)
             global last_weight_scale
             global last_activation_scale
             global last_weight_bit
@@ -204,19 +234,38 @@ class QuantizeLayer(nn.Module):
             self.bit_scale_list.data[0, 0] = last_activation_bit
             self.bit_scale_list.data[0, 1] = last_activation_scale
             weight = Quantize(weight, self.quantize_config['weight_bit'], 'weight', None, None)
+            
             # weight bit and scale
             self.bit_scale_list.data[1, 0] = last_weight_bit
             self.bit_scale_list.data[1, 1] = last_weight_scale
             if self.layer_config['type'] == 'conv':
-                output = F.conv2d(
-                    input, weight, None, \
-                    self.layer_config['stride'], self.layer_config['padding'], 1, 1
-                )
+                
+                if self.layer_config['depthwise']=='normal':
+                    output = F.conv2d(
+                        input, weight, None, \
+                        self.layer_config['stride'], self.layer_config['padding'], 1, 1
+                    )
+                elif self.layer_config['depthwise']=='point':
+                    output = F.conv2d(
+                        input, weight, None, \
+                        self.layer_config['stride'], self.layer_config['padding'], 1,1
+                    )
+                elif self.layer_config['depthwise']=='separable':
+                    output = F.conv2d(
+                        input, weight, None, \
+                        self.layer_config['stride'], self.layer_config['padding'], 1, input.shape[1]
+                    )
+                else :
+                    assert 0, f'not support depthwise'
             elif self.layer_config['type'] == 'fc':
                 output = F.linear(input, weight, None)
             else:
                 assert 0, f'not support {self.layer_config["type"]}'
+            
             output = Quantize(output, self.quantize_config['activation_bit'], 'activation', self.last_value, self.training)
+            
+           
+            
             # output activation bit and scale
             self.bit_scale_list.data[2, 0] = last_activation_bit
             self.bit_scale_list.data[2, 1] = last_activation_scale
@@ -227,12 +276,28 @@ class QuantizeLayer(nn.Module):
             output = self.set_weights_forward(input, bit_weights, adc_action)
             return output
         assert 0, f'not support {METHOD}'
+    #calculate_equal_bit:CNNParted Interfaces
+    def calculate_equal_bit(self):
+        #R:active Rows
+        if layer_config['type']=='conv':
+            k=self.layer_config['kernel_size']
+            Cin=self.layer_config['in_channels']
+            R=self.hardware_config['DAC_num']
+            Padc=self.hardware_config['ADC_quantize_bit']
+            Pout_equal=int(max(math.log2(k**2*Cin/R),0))+Padc
+        elif layer_config['type']=='fc':
+            inputchannel=self.layer_config['in_features']
+            R=self.hardware_config['DAC_num']
+            Pout_equal=int(max(math.log2(inputchannel/R),0))+Padc
+        
+        return Pout_equal
     def get_bit_weights(self):
         weight_bit = self.quantize_config['weight_bit']
         weight_scale = self.bit_scale_list[1, 1].item()
         assert weight_bit != 0 and weight_scale != 0, f'weight bit and scale should be given by the params'
         bit_weights = collections.OrderedDict()
         for layer_num, l in enumerate(self.sublayer_list):
+            
             # assert (weight_bit - 1) % self.hardware_config['weight_bit'] == 0, generate weight part
             if self.hardware_config['xbar_polarity'] == 2:
                 weight_bit_split_part = math.ceil((weight_bit - 1) / self.hardware_config['weight_bit'])
@@ -259,13 +324,18 @@ class QuantizeLayer(nn.Module):
                     # use one xbar to store one weight value
                     bit_weights[f'split{layer_num}_weight{j}'] = tmp
                 base = base * step
+            
         return bit_weights
     def set_weights_forward(self, input, bit_weights, adc_action):
         assert self.training == False
         output = None
+        output_final=None
+        
         input_list = torch.split(input, self.split_input, dim = 1)
             # self.split_input = xbar_size
+        
         scale = self.last_value.item()
+        
         # weight_bit = int(self.bit_scale_list[1, 0].item())
         weight_bit = self.quantize_config['weight_bit']
         weight_scale = self.bit_scale_list[1, 1].item()
@@ -289,6 +359,7 @@ class QuantizeLayer(nn.Module):
                 weight_container.append(tmp.to(device = input.device, dtype = input.dtype))
                 base = base * step
             activation_in_bit = int(self.bit_scale_list[0, 0].item())
+            
             activation_in_scale = self.bit_scale_list[0, 1].item()
             thres = 2 ** (activation_in_bit - 1) - 1
             activation_in_digit = torch.clamp(torch.round(input_list[layer_num] / activation_in_scale), 0 - thres, thres - 0)
@@ -311,10 +382,19 @@ class QuantizeLayer(nn.Module):
                 for j in range(weight_bit_split_part):
                     tmp = None
                     if self.layer_config['type'] == 'conv':
-                        tmp = F.conv2d(
-                            activation_in_container[i], weight_container[j], None, \
-                            self.layer_config['stride'], self.layer_config['padding'], 1, 1
-                        )
+                        if 'depthwise'not in self.layer_config.keys():
+                            self.layer_config['depthwise']='normal'
+                        if self.layer_config['depthwise']=='normal':
+                            tmp = F.conv2d(
+                                activation_in_container[i], weight_container[j], None, \
+                                self.layer_config['stride'], self.layer_config['padding'], 1, 1
+                            )
+                        elif self.layer_config['depthwise']=='separable':
+                            tmp = F.conv2d(
+                                activation_in_container[i], weight_container[j], None, \
+                                self.layer_config['stride'], self.layer_config['padding'], 1, activation_in_container[i].shape[1]
+                            )
+                   
                     elif self.layer_config['type'] == 'fc':
                         tmp = F.linear(activation_in_container[i], weight_container[j], None)
                     else:
@@ -348,17 +428,50 @@ class QuantizeLayer(nn.Module):
                                   (weight_bit_split_part - 1 - j) * self.hardware_config['weight_bit']
                     tmp = tmp / (2 ** scale_point)
                     # add
+                    
+                    #tmp_buffer to execute depthwise convolution
                     if torch.is_tensor(output):
-                        output = output + tmp
+                        if self.layer_config['type'] == 'conv':
+                            if self.layer_config['depthwise']=='separable':
+                                if output.shape==tmp.shape:
+                                    output = output + tmp
+                                else:
+                                    if flag==0:
+                                        tmp_buffer=tmp
+                                        flag=1
+                                    tmp_buffer=tmp_buffer+tmp
+                            else:
+                                output = output + tmp
+                                
+                        else:
+                            output = output + tmp
                     else:
                         output = tmp
+            if self.layer_config['type'] == 'conv':
+                if self.layer_config['depthwise']=='separable' :
+                    if torch.is_tensor(output_final):
+                        if tmp_buffer!=None:
+                            output_final=torch.cat([output_final,tmp_buffer],dim=1)
+                        else:
+                            output_final=torch.cat([output_final,output],dim=1)
+                    else:
+                        if tmp_buffer!=None:
+                            output_final=tmp_buffer
+                        else:
+                            output_final=output
+                else:
+                    output_final=output
+            else:
+                output_final=output
+       
         # quantize output
         activation_out_bit = int(self.bit_scale_list[0, 0].item())
         activation_out_scale = self.bit_scale_list[0, 1].item()
         thres = 2 ** (activation_out_bit - 1) - 1
-        output = torch.clamp(torch.round(output * thres), 0 - thres, thres - 0)
-        output = output * scale / thres
-        return output
+        output_final = torch.clamp(torch.round(output_final * thres), 0 - thres, thres - 0)
+        output_final = output_final * scale / thres
+        return output_final
+
     def extra_repr(self):
         return str(self.hardware_config) + ' ' + str(self.layer_config) + ' ' + str(self.quantize_config)
 QuantizeLayerStr = ['conv', 'fc']
@@ -367,7 +480,8 @@ class ViewLayer(nn.Module):
     def __init__(self):
         super(ViewLayer, self).__init__()
     def forward(self, x):
-        return x.view(x.size(0), -1)
+        x=x.view(x.size(0), -1)
+        return x
 
 class ConcatLayer(nn.Module):
     def __init__(self):
@@ -381,6 +495,31 @@ class EleSumLayer(nn.Module):
         super(EleSumLayer, self).__init__()
     def forward(self, x):
         return x[0] + x[1]
+
+class EleMulLayer(nn.Module):
+    def __init__(self):
+        super(EleMulLayer, self).__init__()
+    def forward(self, x):
+        x[0]=x[0].view(x[0].shape[0],x[0].shape[1],1,1)
+        return x[0]*x[1]
+def drop_path(x, prob: float = 0., training: bool = False):
+    if prob==0 or not training:
+        return x
+    keep=1-prob
+    shape = (x.shape[0],) + (1,) * (x.ndim - 1)  # work with diff dim tensors, not just 2D ConvNets
+    random_tensor = keep + torch.rand(shape, dtype=x.dtype, device=x.device)
+    random_tensor.floor_()  # binarize
+    output = x.div(keep) * random_tensor
+    return output
+    
+
+class droppath(nn.Module):
+    def __init__(self,droppro=None):
+        super(droppath,self).__init__()
+        self.prob=droppro
+    def forward(self,x):
+        x=drop_path(x,self.prob,self.training)
+        return x
 
 class StraightLayer(nn.Module):
     def __init__(self, hardware_config, layer_config, quantize_config):
@@ -396,11 +535,13 @@ class StraightLayer(nn.Module):
             if 'padding' not in self.layer_config.keys():
                 self.layer_config['padding'] = 0
             if self.layer_config['mode'] == 'AVE':
+                
                 self.layer = nn.AvgPool2d(
                     kernel_size = self.layer_config['kernel_size'], \
                     stride = self.layer_config['stride'], \
                     padding = self.layer_config['padding']
                 )
+               
             elif self.layer_config['mode'] == 'MAX':
                 self.layer = nn.MaxPool2d(
                     kernel_size = self.layer_config['kernel_size'], \
@@ -413,12 +554,20 @@ class StraightLayer(nn.Module):
                 assert 0, f'not support {self.layer_config["mode"]}'
         elif self.layer_config['type'] == 'relu':
             self.layer = nn.ReLU()
+        elif self.layer_config['type']=='Swish':
+            self.layer=nn.SiLU()
+        elif self.layer_config['type']=='Sigmoid':
+            self.layer=nn.Sigmoid()
+        elif self.layer_config['type'] == 'element_multiply':
+            self.layer = EleMulLayer()
         elif self.layer_config['type'] == 'view':
             self.layer = ViewLayer()
         elif self.layer_config['type'] == 'bn':
             self.layer = nn.BatchNorm2d(self.layer_config['features'])
         elif self.layer_config['type'] == 'dropout':
-            self.layer = nn.Dropout()
+            self.layer=nn.Dropout(0.2)
+            #self.layer = droppath(0.2)
+            
         elif self.layer_config['type'] == 'element_sum':
             self.layer = EleSumLayer()
         elif self.layer_config['type'] == 'concat':
@@ -426,12 +575,16 @@ class StraightLayer(nn.Module):
         else:
             assert 0, f'not support {self.layer_config["type"]}'
         # self.last_value = nn.Parameter(torch.ones(1))
+        
         self.register_buffer('last_value', torch.ones(1))
+       
         # self.last_value[0] = 1
         self.layer_info = None
     def structure_forward(self, input):
         # get the layer structure of non conv or fc layer
-        if self.layer_config['type'] != 'element_sum' and self.layer_config['type'] != 'concat':
+        #if self.layer_config['type'] != 'element_sum' and self.layer_config['type'] != 'concat':
+        
+        if self.layer_config['type'] != 'element_sum' and self.layer_config['type'] != 'concat' and self.layer_config['type'] != 'element_multiply':
             # generate input shape and output shape
             self.input_shape = input.shape
             output = self.layer.forward(input)
@@ -450,6 +603,12 @@ class StraightLayer(nn.Module):
                 self.layer_info['Outputsize'] = list(self.output_shape)[2:]
             elif self.layer_config['type'] == 'relu':
                 self.layer_info['type'] = 'relu'
+            elif self.layer_config['type']=='Swish':
+                self.layer_info['type']= 'Swish'
+            elif self.layer_config['type']=='Sigmoid':
+                self.layer_info['type']= 'Sigmoid'
+            elif self.layer_config['type']=='Squeeze-Excitation':
+                self.layer_info['type']= 'Squeeze-Excitation'
             elif self.layer_config['type'] == 'view':
                 self.layer_info['type'] = 'view'
             elif self.layer_config['type'] == 'bn':
@@ -475,7 +634,7 @@ class StraightLayer(nn.Module):
             self.layer_info['Inputindex'] = [-1]
         self.layer_info['Outputindex'] = [1]
         return output
-
+    
     def forward(self, input, method = 'SINGLE_FIX_TEST', adc_action = 'SCALE'):
         # DOES NOT use method and adc_action, for unifying with QuantizeLayer
         METHOD = method
@@ -494,4 +653,4 @@ class StraightLayer(nn.Module):
         return None
     def extra_repr(self):
         return str(self.hardware_config) + ' ' + str(self.layer_config) + ' ' + str(self.quantize_config)
-StraightLayerStr = ['pooling', 'relu', 'view', 'concat', 'bn', 'dropout', 'element_sum']
+StraightLayerStr = ['pooling', 'relu','Swish','Sigmoid','view', 'concat', 'bn', 'dropout', 'element_sum','element_multiply']

--- a/MNSIM/Interface/train.py
+++ b/MNSIM/Interface/train.py
@@ -11,11 +11,11 @@ from tensorboardX import SummaryWriter
 tensorboard_writer = None
 
 MOMENTUM = 0.9
-WEIGHT_DECAY = 0.0005
-GAMMA = 0.01
-lr = 0.1
+WEIGHT_DECAY = 0.0001
+GAMMA = 0.06
+lr = 0.01
 MILESTONES = [30, 60]
-EPOCHS = 90
+EPOCHS = 50
 
 TRAIN_PARAMETER = '''\
 # TRAIN_PARAMETER
@@ -33,12 +33,14 @@ WEIGHT_DECAY,
 GAMMA,
 EPOCHS,
 )
-
 def train_net(net, train_loader, test_loader, device, prefix):
     global tensorboard_writer
     tensorboard_writer = SummaryWriter(log_dir = os.path.join(os.path.dirname(__file__), f'runs/{prefix}'))
     # set net on gpu
+    device_ids=[0,1,2,3,4,5,6]
+    net=torch.nn.DataParallel(net,device_ids=device_ids)
     net.to(device)
+    
     # loss and optimizer
     criterion = nn.CrossEntropyLoss()
     # scale's lr and weight_decay set to 0
@@ -48,23 +50,35 @@ def train_net(net, train_loader, test_loader, device, prefix):
     # test init
     # eval_net(net, test_loader, 0, device)
     # epochs
+    
+    #print(prefix)
     for epoch in range(EPOCHS):
         # train
         net.train()
         scheduler.step()
+       
         for i, (images, labels) in enumerate(train_loader):
             net.zero_grad()
+            
             images = images.to(device)
             labels = labels.to(device)
+            #print("labelshape:",labels.shape)
+            
             outputs = net(images, 'FIX_TRAIN')
+            
+            #print("finalloss:",outputs.shape,labels.shape)
             loss = criterion(outputs, labels)
             loss.backward()
             optimizer.step()
             print(f'epoch {epoch+1:3d}, {i:3d}|{len(train_loader):3d}, loss: {loss.item():2.4f}', end = '\r')
             tensorboard_writer.add_scalars('train_loss', {'train_loss': loss.item()}, epoch * len(train_loader) + i)
-        eval_net(net, test_loader, epoch + 1, device)
-        torch.save(net.state_dict(), os.path.join(os.path.dirname(__file__), f'zoo/{prefix}_params.pth'))
 
+        eval_net(net, test_loader, epoch + 1, device)
+        torch.save(net.state_dict(), os.path.join(os.path.dirname(__file__), f'zoo/{prefix}_99qbitpim_params.pth'))
+       
+        torch.cuda.empty_cache()
+   
+        
 def eval_net(net, test_loader, epoch, device):
     # set net on gpu
     net.to(device)
@@ -73,6 +87,7 @@ def eval_net(net, test_loader, epoch, device):
     test_total = 0
     with torch.no_grad():
         for i, (images, labels) in enumerate(test_loader):
+            
             images = images.to(device)
             test_total += labels.size(0)
             outputs = net(images, 'FIX_TRAIN')

--- a/MNSIM/Latency_Model/tempCodeRunnerFile.py
+++ b/MNSIM/Latency_Model/tempCodeRunnerFile.py
@@ -1,0 +1,1 @@
+temp_tile_latency.outbuf.buf_rlatency

--- a/MNSIM/Power_Model/Model_inference_power.py
+++ b/MNSIM/Power_Model/Model_inference_power.py
@@ -130,6 +130,9 @@ class Model_inference_power():
                 if layer_dict['type'] == 'element_sum':
                     print("     Hardware power (global accumulator):", self.global_add.adder_power*self.graph.global_adder_num
                           +self.global_buf.buf_wpower*1e-3+self.global_buf.buf_rpower*1e-3, "W")
+                elif layer_dict['type'] == 'element_multiply':
+                    print("     Hardware power (global accumulator):", self.global_add.adder_power*self.graph.global_multiplier_num
+                          +self.global_buf.buf_wpower*1e-3+self.global_buf.buf_rpower*1e-3, "W")
                 else:
                     print("     Hardware power:", self.arch_power[i], "W")
 if __name__ == '__main__':

--- a/SimConfig.ini
+++ b/SimConfig.ini
@@ -33,7 +33,7 @@ Device_Resistance = 1e6, 1e4
 Device_Variation = 1
 # only used for NVM
 # x% of ideal resistance
-Device_SAF = 1,1
+Device_SAF = 0.1,0.1
 # only used for NVM
 # X% of Stuck-At-HRS and Stuck-At-LRS
 Read_Energy = 1.12e-15
@@ -72,7 +72,7 @@ DAC_Power = 0
 # DAC power option: 0: default configurations, x: unit W
 DAC_Sample_Rate = 0
 # DAC sample rate option: 0: default configurations, x: GSamples/s
-ADC_Choice = 2
+ADC_Choice = 6
 # ADC choice option: -1: User defined, 1~8: eight default configurations
 # especially, ADC_Choice 8 means SA
 ADC_Area = 0
@@ -101,7 +101,7 @@ Sub_Position = 0
 # 0: the subtraction of pos and neg xbar is performed in the analog domain; 1: in the digital domain (sub after ADC quantization)
 Group_Num = 1
 # number of crossbar groups
-DAC_Num = 256
+DAC_Num = 128
 # number of DAC per *subarray* in each group: 0: default configuration, x: user defined
 ADC_Num = 128
 # number of ADC per *subarray* in each group: 0: default configuration, x: user defined
@@ -123,6 +123,11 @@ Adder_Area = 0
 # adder area option: 0:default configurations x: unit um^2
 Adder_Power = 0
 # adder power option: 0:default configurations x: unit W
+#linqiushi modified
+Multiplier_Tech=45
+Multiplier_Area=0
+Multiplier_Power=0
+#linqiushi above
 ShiftReg_Tech = 65
 # shiftreg technology unit: nm
 ShiftReg_Area = 0
@@ -196,7 +201,9 @@ LUT_Bandwidth = 0
 # LUT bandwidth option: 0: default configurations, x:Mb/s
 Tile_Connection = 2
 # Option: 0, 1, 2, 3
+
 Tile_Num = 64,64
+
 # number of Tiles in accelerator (x,y): 0,0: default configuration (8x8), x,y: user defined
 
 ########### Algorithm Configuration ################

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def main():
         help="Disable hardware modeling, default: false")
     parser.add_argument("-DisAccu", "--disable_accuracy_simulation", action='store_true', default=False,
         help="Disable accuracy simulation, default: false")
-    parser.add_argument("-SAF", "--enable_SAF", action='store_true', default=False,
+    parser.add_argument("-SAF", "--enable_SAF", action='store_true', default=True,
         help="Enable simulate SAF, default: false")
     parser.add_argument("-Var", "--enable_variation", action='store_true', default=False,
         help="Enable simulate variation, default: false")
@@ -68,10 +68,13 @@ def main():
         print("Quantization range: fixed range (depends on the maximum value)")
     else:
         print("Quantization range: dynamic range (depends on the data distribution)")
-
+   
     mapping_start_time = time.time()
+    
+    #cifar10/cifar100/Imagenet
     __TestInterface = TrainTestInterface(network_module=args.NN, dataset_module='MNSIM.Interface.cifar10',  
         SimConfig_path=args.hardware_description, weights_file=args.weights, device=args.device)
+   
     structure_file = __TestInterface.get_structure()
     TCG_mapping = TCG(structure_file, args.hardware_description)
     # print(TCG_mapping.max_inbuf_size)
@@ -83,6 +86,7 @@ def main():
         if not (args.disable_inner_pipeline):
             __latency.calculate_model_latency(mode=1)
             # __latency.calculate_model_latency_nopipe()
+            
         else:
             __latency.calculate_model_latency_nopipe()
         hardware_modeling_end_time = time.time()
@@ -90,6 +94,7 @@ def main():
         __latency.model_latency_output(not (args.disable_module_output), not (args.disable_layer_output))
 
         __area = Model_area(NetStruct=structure_file, SimConfig_path=args.hardware_description, TCG_mapping=TCG_mapping)
+        
         print("========================Area Results=================================")
         __area.model_area_output(not (args.disable_module_output), not (args.disable_layer_output))
         __power = Model_inference_power(NetStruct=structure_file, SimConfig_path=args.hardware_description,
@@ -107,6 +112,7 @@ def main():
         print("Accuracy simulation will take a few minutes on GPU")
         accuracy_modeling_start_time = time.time()
         weight = __TestInterface.get_net_bits()
+        
         weight_2 = weight_update(args.hardware_description, weight,
                                  is_Variation=args.enable_variation, is_SAF=args.enable_SAF, is_Rratio=args.enable_R_ratio)
         if not (args.enable_fixed_Qrange):


### PR DESCRIPTION
1.将SAF概率的值从int变成了float（比如原来只能是1%，现在可以设置为1.1%）
2.添加了新算子：element_multiply（逐元素乘）,depthwise convolution（深度可分离卷积，与quantize层有关），droppath（与dropout不同），Swish，Sigmoid
3.为了element_multiply的仿真设计了multiplier乘法器，仿照adder的代码；
TODO:补全乘法器Multiplier.py中的area、power参数
4.添加了ImageNet的接口
TODO：尝试在cifar100和ImageNet上做QAT训练
5.在Network.py中添加了EfficientNet
6.变为多卡训练
7.在layer latency的计算中修正了“相邻层”的序号表示（原来是-1，现在是+input_index[0]），避免了resnet18中出现的负latency
TODO:除此之外还有另外一个layer latency出现负值的bug 出现在alexnet_Imagenet的pooling中，需要考虑为layer latency的计算添加一些特殊条件
